### PR TITLE
get method overload with delegate.

### DIFF
--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -77,6 +77,19 @@ namespace HarmonyLib
 			}
 		}
 
+		/// <summary>Gets parameter types from delegate</summary>
+		/// <typeparam name="TDelegate">delegate type</typeparam>
+		/// <param name="instance">skip first parameter.</param>
+		/// <returns>Type[] representing parameters of the delegate.</returns>
+		internal static Type[] GetParameterTypes<TDelegate>(bool instance = false) where TDelegate : Delegate
+		{
+			IEnumerable<ParameterInfo> parameters = typeof(TDelegate).GetMethod("Invoke").GetParameters();
+			if (instance)
+				parameters = parameters.Skip(1);
+
+			return parameters.Select(p => p.ParameterType).ToArray();
+		}
+
 		/// <summary>Applies a function going up the type hierarchy and stops at the first non-<c>null</c> result</summary>
 		/// <typeparam name="T">Result type of func()</typeparam>
 		/// <param name="type">The class/type to start with</param>
@@ -317,6 +330,19 @@ namespace HarmonyLib
 			return result;
 		}
 
+		/// <summary>Gets the reflection information for a directly declared method</summary>
+		/// <typeparam name="TDelegate">delegate that has the same argument types as the intented overloaded method</typeparam>
+		/// <param name="type">The class/type where the method is declared</param>
+		/// <param name="name">The name of the method (case sensitive). Uses delegate name by default.</param>
+		/// <param name="instance">is instance delegate (skips the first parameter)</param>
+		/// <returns>A method or null when type/name is null or when the method cannot be found</returns>
+		internal static MethodInfo DeclaredMethod<TDelegate>(Type type, string name = null, bool instance = false)
+			 where TDelegate : Delegate
+		{
+			var args = GetParameterTypes<TDelegate>(instance);
+			return DeclaredMethod(type, name ?? typeof(TDelegate).Name, args);
+		}
+
 		/// <summary>Gets the reflection information for a method by searching the type and all its super types</summary>
 		/// <param name="type">The class/type where the method is declared</param>
 		/// <param name="name">The name of the method (case sensitive)</param>
@@ -391,6 +417,33 @@ namespace HarmonyLib
 
 			var type = TypeByName(parts[0]);
 			return DeclaredMethod(type, parts[1], parameters, generics);
+		}
+
+		/// <summary>Gets the reflection information for a method by searching the type and all its super types</summary>
+		/// <summary>Gets the reflection information for a directly declared method</summary>
+		/// <typeparam name="TDelegate">delegate that has the same argument types as the intented overloaded method</typeparam>
+		/// <param name="type">The class/type where the method is declared</param>
+		/// <param name="name">The name of the method (case sensitive). Uses delegate name by default.</param>
+		/// <param name="instance">is instance delegate (skips the first parameter)</param>
+		/// <returns>A method or null when type/name is null or when the method cannot be found</returns>
+		internal static MethodInfo Method<TDelegate>(Type type, string name = null, bool instance = false)
+			 where TDelegate : Delegate
+		{
+			var args = GetParameterTypes<TDelegate>(instance);
+			return Method(type, name ?? typeof(TDelegate).Name, args);
+		}
+
+		/// <summary>Gets the reflection information for a method by searching the type and all its super types</summary>
+		/// <summary>Gets the reflection information for a directly declared method</summary>
+		/// <typeparam name="TDelegate">delegate that has the same argument types as the intented overloaded method</typeparam>
+		/// <param name="typeColonMethodname">The target method in the form <c>TypeFullName:MethodName</c>, where the type name matches a form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <c>Some.Namespace.Type</c>.</param>
+		/// <param name="instance">is instance delegate (skips the first parameter)</param>
+		/// <returns>A method or null when type/name is null or when the method cannot be found</returns>
+		internal static MethodInfo Method<TDelegate>(string typeColonMethodname, bool instance = false)
+			 where TDelegate : Delegate
+		{
+			var args = GetParameterTypes<TDelegate>(instance);
+			return Method(typeColonMethodname, args);
 		}
 
 		/// <summary>Gets the names of all method that are declared in a type</summary>

--- a/HarmonyTests/Tools/Assets/AccessToolsClass.cs
+++ b/HarmonyTests/Tools/Assets/AccessToolsClass.cs
@@ -109,6 +109,15 @@ namespace HarmonyLibTests.Assets
 		{
 			return field4;
 		}
+
+		public object Method5()
+		{
+			return null;
+		}
+		public static object Method5(int x)
+		{
+			return null;
+		}
 	}
 
 	public class AccessToolsSubClass : AccessToolsClass

--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -315,6 +315,23 @@ namespace HarmonyLibTests.Tools
 			Assert.Null(AccessTools.DeclaredMethod(interfaceType, "unknown"));
 		}
 
+		delegate object Method5(int x);
+
+		[Test]
+		public void Test_AccessTools_Method3()
+		{
+			var classType = typeof(AccessToolsClass);
+			Assert.NotNull(AccessTools.DeclaredMethod<Func<object>>(classType, "Method5"));
+			Assert.NotNull(AccessTools.DeclaredMethod<Method5>(classType));
+			Assert.Null(AccessTools.DeclaredMethod<Func<int,int,object>>(classType, "Method5"));
+
+			Assert.NotNull(AccessTools.Method<Func<object>>(classType, "Method5"));
+			Assert.NotNull(AccessTools.Method<Method5>("HarmonyLibTests.Assets.AccessToolsClass:Method5"));
+			Assert.NotNull(AccessTools.Method<Func<int, object>>(classType, "Method5"));
+			Assert.Null(AccessTools.Method<Func<int, int, object>>(classType, "Method5"));
+		}
+
+
 		[Test]
 		public void Test_AccessTools_InnerClass()
 		{


### PR DESCRIPTION
added:
```
MethodInfo Method<TDelegate>(arguemnts)
MethodInfo DeclaredMethod<TDelegate>(arguemnts)
Type [] GetParameterTypes<TDelegate>(arguments) 
````
will add `code.Calls<TDelegate>(arguments)  in another review
# Test result:
![image](https://user-images.githubusercontent.com/26344691/119412426-87201180-bcf4-11eb-84a4-988b70923b1b.png)
